### PR TITLE
remove redundant step in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ This repository provides the tools for constructing the whole of InLoc datset in
 
 ## Usage
 
-1. Download transformation matrices from <http://cvpr17.wijmans.xyz/> in the zip format. Put all zip files to ``database/alignments/zips/``. 
-
 2. Download and extract all database files: Run ``./extract_db_all.sh`` in the terminal. 
 
 3. Download and extract query images: Run ``extract_query.sh`` in the terminal. 


### PR DESCRIPTION
Its not necessary to manually download these files, as they are being downloaded in `extract_db_all.sh`.